### PR TITLE
feat: bootstrap headless tabs library

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+src
+node_modules
+vitest.config.*
+tsconfig.json
+tsconfig.*.json
+.eslintrc.*
+*.log
+coverage

--- a/README.md
+++ b/README.md
@@ -1,2 +1,97 @@
-# React-Tabs
-Headless Tabs in React
+# Headless Tabs
+
+A small, headless controller for orchestrating tabbed workflows in React applications. The library ships two components – `Tabs` and `TabFeature` – that work together similarly to `Router`/`Route`: declare the shape of each supported tab via `TabFeature` and feed the `Tabs` controller with the active tab instances.
+
+## Installation
+
+```bash
+npm install @acme/headless-tabs
+```
+
+## Quick start
+
+```tsx
+import { TabFeature, Tabs } from '@acme/headless-tabs';
+
+type ProfileTab = {
+  id: string;
+  type: 'profile';
+  state: { userId: string };
+};
+
+type SettingsTab = {
+  id: string;
+  type: 'settings';
+  state: { section: 'general' | 'notifications' };
+};
+
+type MyTab = ProfileTab | SettingsTab;
+
+const activeTabs: MyTab[] = [
+  { id: '1', type: 'profile', state: { userId: '123' } },
+  { id: '2', type: 'settings', state: { section: 'general' } },
+];
+
+export function Example() {
+  return (
+    <Tabs tabs={activeTabs} defaultActiveTabId="1">
+      <TabFeature
+        type="profile"
+        render={({ tab, isActive, activate }) => (
+          <button onClick={activate} aria-pressed={isActive}>
+            Profile for {tab.state.userId}
+          </button>
+        )}
+      />
+
+      <TabFeature
+        type="settings"
+        render={({ tab, isActive, activate }) => (
+          <button onClick={activate} aria-pressed={isActive}>
+            Settings ({tab.state.section})
+          </button>
+        )}
+      />
+    </Tabs>
+  );
+}
+```
+
+The `Tabs` component enforces that the `tabs` prop matches the union of tab shapes declared via `TabFeature`. Each feature provides a `render` callback that receives:
+
+- `tab`: The strongly typed tab instance.
+- `isActive`: Whether the tab is the currently selected tab.
+- `activate()`: Function that selects the tab.
+- `close?()`: Function that requests the tab to be closed (only provided when `onTabClose` is supplied on `Tabs`).
+
+### Controlled vs uncontrolled
+
+Provide `activeTabId` to control which tab is active. Alternatively, use `defaultActiveTabId` for uncontrolled usage. `onTabChange` fires whenever the active tab changes.
+
+### Handling tab closure
+
+Pass an `onTabClose` handler to react to tab close requests. When omitted the `close` handler will be `undefined`, allowing features to hide close affordances entirely.
+
+## API
+
+### `<Tabs />`
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `tabs` | `TabUnion<typeof children>[]` | Collection of tab instances to display. |
+| `activeTabId` | `string` | (Controlled) identifier of the active tab. |
+| `defaultActiveTabId` | `string` | Initial active tab in uncontrolled mode. |
+| `onTabChange` | `(tab) => void` | Called when a different tab becomes active. |
+| `onTabClose` | `(tab) => void` | Called when a tab requests to be closed. |
+| `renderEmpty` | `() => ReactNode` | Rendered when `tabs` is empty. |
+
+### `<TabFeature />`
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `type` | `string` | Discriminator linking a tab instance with its feature. |
+| `render` | `(context) => ReactNode` | Render logic for the tab instance. |
+
+## License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@acme/headless-tabs",
+  "version": "0.1.0",
+  "description": "A headless, type-safe controller for tabbed workflows in React.",
+  "keywords": [
+    "react",
+    "tabs",
+    "headless",
+    "state-machine"
+  ],
+  "license": "MIT",
+  "author": "",
+  "repository": {
+    "type": "git",
+    "url": "git+https://example.com/acme/headless-tabs.git"
+  },
+  "bugs": {
+    "url": "https://example.com/acme/headless-tabs/issues"
+  },
+  "homepage": "https://example.com/acme/headless-tabs#readme",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup",
+    "lint": "tsc --noEmit",
+    "test": "vitest"
+  },
+  "peerDependencies": {
+    "react": ">=17.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^14.1.2",
+    "@types/node": "^20.11.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "jsdom": "^23.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "tsup": "^7.2.0",
+    "typescript": "^5.3.0",
+    "vitest": "^1.3.0"
+  }
+}

--- a/src/TabFeature.tsx
+++ b/src/TabFeature.tsx
@@ -1,0 +1,14 @@
+import type { JSX } from 'react';
+import type { TabFeatureProps } from './types';
+
+function TabFeatureComponent<Type extends string, State>(
+  _: TabFeatureProps<Type, State>,
+): JSX.Element | null {
+  return null;
+}
+
+TabFeatureComponent.displayName = 'TabFeature';
+
+export const TabFeature = TabFeatureComponent;
+
+export type { TabFeatureProps } from './types';

--- a/src/Tabs.test.tsx
+++ b/src/Tabs.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { TabFeature, Tabs } from './index';
+
+describe('Tabs', () => {
+  it('renders each tab with the matching feature', () => {
+    const tabs = [
+      { id: 'profile-1', type: 'profile', state: { userId: '123' } },
+      { id: 'settings-1', type: 'settings', state: { section: 'general' } },
+    ] as const;
+
+    const { getByRole, getByText } = render(
+      <Tabs tabs={tabs} defaultActiveTabId="profile-1">
+        <TabFeature
+          type="profile"
+          render={({ tab, isActive, activate }) => (
+            <button type="button" onClick={activate} aria-pressed={isActive}>
+              Profile {tab.state.userId}
+            </button>
+          )}
+        />
+        <TabFeature
+          type="settings"
+          render={({ tab }) => <span>Settings: {tab.state.section}</span>}
+        />
+      </Tabs>,
+    );
+
+    expect(getByRole('button', { name: /Profile 123/i })).toBeTruthy();
+    expect(getByText(/Settings: general/i)).toBeTruthy();
+  });
+
+  it('exposes activate and close callbacks', () => {
+    const tabs = [{ id: 'profile-1', type: 'profile', state: { userId: '123' } }] as const;
+    const handleChange = vi.fn();
+    const handleClose = vi.fn();
+
+    const { getByRole } = render(
+      <Tabs tabs={tabs} onTabChange={handleChange} onTabClose={handleClose}>
+        <TabFeature
+          type="profile"
+          render={({ activate, close, isActive }) => (
+            <button
+              type="button"
+              aria-pressed={isActive}
+              onClick={() => {
+                activate();
+                close?.();
+              }}
+            >
+              Toggle
+            </button>
+          )}
+        />
+      </Tabs>,
+    );
+
+    fireEvent.click(getByRole('button', { name: /Toggle/i }));
+
+    expect(handleChange).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'profile-1', type: 'profile' }),
+    );
+    expect(handleClose).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'profile-1', type: 'profile' }),
+    );
+  });
+});

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -1,0 +1,143 @@
+import {
+  Children,
+  isValidElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type JSX,
+  type ReactNode,
+} from 'react';
+import { TabFeature } from './TabFeature';
+import type {
+  AnyTabFeatureElement,
+  TabFeatureElement,
+  TabRenderContext,
+  TabUnion,
+  TabsProps,
+} from './types';
+
+function isTabFeatureElement<Type extends string, State>(
+  child: unknown,
+): child is TabFeatureElement<Type, State> {
+  return isValidElement(child) && child.type === TabFeature;
+}
+
+const warn = (message: string) => {
+  if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.warn(message);
+  }
+};
+
+function useFeatureRegistry(children: TabsProps<readonly AnyTabFeatureElement[]>['children']) {
+  return useMemo(() => {
+    const registry = new Map<string, AnyTabFeatureElement>();
+    Children.forEach(children as unknown as ReactNode, (child) => {
+      if (isTabFeatureElement(child)) {
+        if (registry.has(child.props.type)) {
+          warn(`Duplicate TabFeature with type "${child.props.type}" was ignored.`);
+          return;
+        }
+        registry.set(child.props.type, child as AnyTabFeatureElement);
+      }
+    });
+    return registry;
+  }, [children]);
+}
+
+export function Tabs<Features extends readonly AnyTabFeatureElement[]>(
+  props: TabsProps<Features>,
+): JSX.Element | null {
+  const {
+    tabs,
+    children,
+    activeTabId: controlledActiveId,
+    defaultActiveTabId,
+    onTabChange,
+    onTabClose,
+    renderEmpty,
+  } = props;
+
+  const features = useFeatureRegistry(children);
+
+  const [uncontrolledActiveId, setUncontrolledActiveId] = useState<string | undefined>(() => {
+    if (controlledActiveId !== undefined) {
+      return controlledActiveId;
+    }
+    if (defaultActiveTabId !== undefined) {
+      return defaultActiveTabId;
+    }
+    return tabs[0]?.id;
+  });
+
+  useEffect(() => {
+    if (controlledActiveId !== undefined) {
+      setUncontrolledActiveId((prev) => (prev === controlledActiveId ? prev : controlledActiveId));
+    }
+  }, [controlledActiveId]);
+
+  useEffect(() => {
+    if (controlledActiveId !== undefined) {
+      return;
+    }
+    setUncontrolledActiveId((current) => {
+      if (current && tabs.some((tab) => tab.id === current)) {
+        return current;
+      }
+      return tabs[0]?.id ?? current;
+    });
+  }, [controlledActiveId, tabs]);
+
+  const activeTabId = controlledActiveId ?? uncontrolledActiveId;
+
+  const handleActivate = useCallback(
+    (tab: TabUnion<Features>) => {
+      if (controlledActiveId === undefined) {
+        setUncontrolledActiveId(tab.id);
+      }
+      onTabChange?.(tab);
+    },
+    [controlledActiveId, onTabChange],
+  );
+
+  const handleClose = useCallback(
+    (tab: TabUnion<Features>) => {
+      onTabClose?.(tab);
+      if (controlledActiveId === undefined && tab.id === uncontrolledActiveId) {
+        const next = tabs.find((candidate) => candidate.id !== tab.id);
+        setUncontrolledActiveId(next?.id);
+      }
+    },
+    [controlledActiveId, onTabClose, tabs, uncontrolledActiveId],
+  );
+
+  if (tabs.length === 0) {
+    if (renderEmpty) {
+      return <>{renderEmpty()}</>;
+    }
+    return null;
+  }
+
+  const renderedTabs = tabs.map((tab) => {
+    const feature = features.get(tab.type);
+    if (!feature) {
+      warn(`No TabFeature found for tab type "${tab.type}".`);
+      return null;
+    }
+
+    const typedTab = tab as TabUnion<Features>;
+    const context: TabRenderContext<TabUnion<Features>> = {
+      tab: typedTab,
+      isActive: tab.id === activeTabId,
+      activate: () => handleActivate(typedTab),
+      close: onTabClose ? () => handleClose(typedTab) : undefined,
+    };
+
+    return feature.props.render(context);
+  });
+
+  return <>{renderedTabs}</>;
+}
+
+export type { TabsProps } from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,10 @@
+export { Tabs } from './Tabs';
+export { TabFeature } from './TabFeature';
+export type {
+  TabFeatureProps,
+  TabInstance,
+  TabRenderContext,
+  TabsProps,
+  TabUnion,
+  ExtractTabOfType,
+} from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,57 @@
+import type { ReactElement, ReactNode } from 'react';
+
+/**
+ * Represents a tab instance managed by the {@link Tabs} controller.
+ */
+export interface TabInstance<Type extends string, State> {
+  id: string;
+  type: Type;
+  state: State;
+}
+
+/**
+ * API exposed to the render function of a {@link TabFeature}.
+ */
+export interface TabRenderContext<Tab extends TabInstance<string, unknown>> {
+  tab: Tab;
+  isActive: boolean;
+  activate: () => void;
+  close?: () => void;
+}
+
+/**
+ * Configuration provided by a {@link TabFeature}.
+ */
+export interface TabFeatureProps<Type extends string, State> {
+  type: Type;
+  render: (context: TabRenderContext<TabInstance<Type, State>>) => ReactNode;
+}
+
+export type TabFeatureElement<Type extends string, State> = ReactElement<
+  TabFeatureProps<Type, State>,
+  typeof import('./TabFeature').TabFeature
+>;
+
+export type AnyTabFeatureElement = TabFeatureElement<string, unknown>;
+
+export type TabUnion<Features extends readonly AnyTabFeatureElement[]> = Features[number] extends TabFeatureElement<
+  infer Type,
+  infer State
+>
+  ? TabInstance<Type, State>
+  : never;
+
+export type ExtractTabOfType<
+  Tabs extends readonly TabInstance<string, unknown>[],
+  Type extends Tabs[number]['type']
+> = Extract<Tabs[number], { type: Type }>;
+
+export interface TabsProps<Features extends readonly AnyTabFeatureElement[]> {
+  tabs: readonly TabUnion<Features>[];
+  activeTabId?: string;
+  defaultActiveTabId?: string;
+  onTabChange?: (tab: TabUnion<Features>) => void;
+  onTabClose?: (tab: TabUnion<Features>) => void;
+  children: Features;
+  renderEmpty?: () => ReactNode;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "types": ["vitest/globals"]
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  minify: false,
+  target: 'es2019',
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: [],
+  },
+});


### PR DESCRIPTION
## Summary
- initialize the package metadata, build tooling, and test harness for a headless tabs utility
- implement the type-safe Tabs controller and TabFeature declaration components with supporting types and docs
- add basic interaction tests covering feature rendering and controller callbacks

## Testing
- `npm install` *(fails: registry access forbidden in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd393dee7883269fa3186728a93f52