### PR TITLE
feat: add tab component factory

### DIFF
--- a/src/factory/README.md
+++ b/src/factory/README.md
@@ -1,0 +1,34 @@
+# Tab Factory
+
+This directory provides a schema-driven `TabFactory` utility for rendering tabs from validated data definitions. Each tab pairs a unique key, a Zod schema that includes the literal key, and a render function that transforms parsed data into a React element.
+
+## Usage
+
+```tsx
+import { z } from 'zod';
+import { TabFactory } from '../factory/TabFactory';
+
+const infoTab = {
+  key: 'info',
+  schema: z.object({
+    key: z.literal('info'),
+    title: z.string(),
+  }),
+  render: ({ title }) => <h1>{title}</h1>,
+} as const;
+
+const detailsTab = {
+  key: 'details',
+  schema: z.object({
+    key: z.literal('details'),
+    description: z.string(),
+  }),
+  render: ({ description }) => <p>{description}</p>,
+} as const;
+
+const tabs = new TabFactory([infoTab, detailsTab]);
+
+const element = tabs.render({ key: 'info', title: 'Welcome' });
+```
+
+Provide raw tab data to `render`, and the factory validates it against the discriminated union schema before invoking the appropriate renderer. Pass an `ErrorComponent` via the constructor options to render a fallback instead of throwing when validation fails.

--- a/src/factory/README.md
+++ b/src/factory/README.md
@@ -6,25 +6,29 @@ This directory provides a schema-driven `TabFactory` utility for rendering tabs 
 
 ```tsx
 import { z } from 'zod';
-import { TabFactory } from '../factory/TabFactory';
+import { TabFactory, type TabPrototype } from '../factory';
 
-const infoTab = {
+const infoSchema = z.object({
+  key: z.literal('info'),
+  title: z.string(),
+});
+
+const infoTab: TabPrototype<'info', typeof infoSchema> = {
   key: 'info',
-  schema: z.object({
-    key: z.literal('info'),
-    title: z.string(),
-  }),
+  schema: infoSchema,
   render: ({ title }) => <h1>{title}</h1>,
-} as const;
+};
 
-const detailsTab = {
+const detailsSchema = z.object({
+  key: z.literal('details'),
+  description: z.string(),
+});
+
+const detailsTab: TabPrototype<'details', typeof detailsSchema> = {
   key: 'details',
-  schema: z.object({
-    key: z.literal('details'),
-    description: z.string(),
-  }),
+  schema: detailsSchema,
   render: ({ description }) => <p>{description}</p>,
-} as const;
+};
 
 const tabs = new TabFactory([infoTab, detailsTab]);
 

--- a/src/factory/README.md
+++ b/src/factory/README.md
@@ -6,33 +6,40 @@ This directory provides a schema-driven `TabFactory` utility for rendering tabs 
 
 ```tsx
 import { z } from 'zod';
-import { TabFactory, type TabPrototype } from '../factory';
+import {
+  TabFactory,
+  createTabFactoryBuilder,
+  createTabPrototype,
+} from '../factory';
 
 const infoSchema = z.object({
   key: z.literal('info'),
   title: z.string(),
 });
 
-const infoTab: TabPrototype<'info', typeof infoSchema> = {
+const infoTab = createTabPrototype({
   key: 'info',
   schema: infoSchema,
   render: ({ title }) => <h1>{title}</h1>,
-};
+});
 
 const detailsSchema = z.object({
   key: z.literal('details'),
   description: z.string(),
 });
 
-const detailsTab: TabPrototype<'details', typeof detailsSchema> = {
+const detailsTab = createTabPrototype({
   key: 'details',
   schema: detailsSchema,
   render: ({ description }) => <p>{description}</p>,
-};
+});
 
-const tabs = new TabFactory([infoTab, detailsTab]);
+const factoryFromArray = new TabFactory([infoTab, detailsTab]);
 
-const element = tabs.render({ key: 'info', title: 'Welcome' });
+const builder = createTabFactoryBuilder().add(infoTab).add(detailsTab);
+const factoryFromBuilder = builder.build();
+
+const element = factoryFromBuilder.render({ key: 'info', title: 'Welcome' });
 ```
 
 Provide raw tab data to `render`, and the factory validates it against the discriminated union schema before invoking the appropriate renderer. Pass an `ErrorComponent` via the constructor options to render a fallback instead of throwing when validation fails.

--- a/src/factory/TabFactory.ts
+++ b/src/factory/TabFactory.ts
@@ -1,0 +1,114 @@
+import { createElement, type ComponentType, type ReactElement } from 'react';
+import { z } from 'zod';
+
+export type ErrorComponentProps = { error?: string };
+
+export interface TabFactoryOptions {
+  readonly ErrorComponent?: ComponentType<ErrorComponentProps>;
+}
+
+type SchemaWithLiteralKey<Key extends string> = z.ZodType<
+  { key: Key } & Record<string, unknown>
+>;
+
+export interface TabPrototype<
+  Key extends string,
+  Schema extends SchemaWithLiteralKey<Key>
+> {
+  readonly key: Key;
+  readonly schema: Schema;
+  readonly render: (value: z.infer<Schema>) => ReactElement;
+}
+
+type AnyTabPrototype = TabPrototype<string, SchemaWithLiteralKey<string>>;
+type PrototypeUnion<T extends readonly AnyTabPrototype[]> = T[number];
+type PrototypeSchema<T> = T extends TabPrototype<any, infer Schema> ? Schema : never;
+type SchemaTuple<T extends readonly AnyTabPrototype[]> = {
+  [Index in keyof T]: PrototypeSchema<T[Index]>;
+};
+type PrototypeValue<T> = T extends TabPrototype<any, infer Schema>
+  ? z.infer<Schema>
+  : never;
+type FactoryInput<T extends readonly AnyTabPrototype[]> = PrototypeValue<
+  PrototypeUnion<T>
+>;
+type FactoryKey<T extends readonly AnyTabPrototype[]> = PrototypeUnion<T>["key"];
+type PrototypeForKey<
+  T extends readonly AnyTabPrototype[],
+  Key extends FactoryKey<T>
+> = Extract<PrototypeUnion<T>, { key: Key }>;
+type FactoryInputByKey<
+  T extends readonly AnyTabPrototype[],
+  Key extends FactoryKey<T>
+> = Extract<FactoryInput<T>, { key: Key }>;
+
+export class TabFactory<Prototypes extends readonly AnyTabPrototype[]> {
+  private readonly prototypeMap: Map<FactoryKey<Prototypes>, PrototypeUnion<Prototypes>>;
+  private readonly unionSchema: z.ZodDiscriminatedUnion<
+    'key',
+    SchemaTuple<Prototypes>[number]
+  >;
+  private readonly ErrorComponent?: ComponentType<ErrorComponentProps>;
+
+  constructor(prototypes: Prototypes, options?: TabFactoryOptions) {
+    if (!prototypes.length) {
+      throw new Error('TabFactory requires at least one tab prototype.');
+    }
+
+    this.prototypeMap = new Map(
+      prototypes.map((prototype) => [prototype.key, prototype])
+    );
+
+    if (this.prototypeMap.size !== prototypes.length) {
+      throw new Error('TabFactory prototypes must have unique keys.');
+    }
+
+    const schemas = prototypes.map((prototype) => prototype.schema) as SchemaTuple<Prototypes>;
+    this.unionSchema = z.discriminatedUnion('key', schemas);
+    this.ErrorComponent = options?.ErrorComponent;
+  }
+
+  public render(data: FactoryInput<Prototypes>): ReactElement;
+  public render(data: unknown): ReactElement {
+    try {
+      const parsed = this.unionSchema.parse(data);
+      const key = parsed.key as FactoryKey<Prototypes>;
+      const prototype = this.getPrototype(key);
+
+      if (!prototype) {
+        throw new Error(`No tab prototype registered for key "${String(key)}".`);
+      }
+
+      return prototype.render(
+        parsed as FactoryInputByKey<Prototypes, typeof key>
+      );
+    } catch (error) {
+      if (this.ErrorComponent) {
+        const ErrorComponent = this.ErrorComponent;
+        return createElement(ErrorComponent, {
+          error: this.serializeError(error),
+        });
+      }
+
+      throw error;
+    }
+  }
+
+  private getPrototype<Key extends FactoryKey<Prototypes>>(
+    key: Key
+  ): PrototypeForKey<Prototypes, Key> | undefined {
+    return this.prototypeMap.get(key) as PrototypeForKey<Prototypes, Key> | undefined;
+  }
+
+  private serializeError(error: unknown): string | undefined {
+    try {
+      return JSON.stringify(
+        error instanceof Error
+          ? { message: error.message, stack: error.stack }
+          : error
+      );
+    } catch {
+      return undefined;
+    }
+  }
+}

--- a/src/factory/TabFactoryBuilder.ts
+++ b/src/factory/TabFactoryBuilder.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+
+import { TabFactory, type TabFactoryOptions } from './TabFactory';
+import type { AnyTabPrototype } from './TabPrototype';
+
+function assertObjectSchema(schema: AnyTabPrototype['schema']): z.ZodObject<any> {
+  if (!(schema instanceof z.ZodObject)) {
+    throw new Error(
+      'TabFactoryBuilder requires each schema to be created via z.object so the key literal can be verified.'
+    );
+  }
+
+  return schema;
+}
+
+function ensureSchemaHasLiteralKey(prototype: AnyTabPrototype): void {
+  const schema = assertObjectSchema(prototype.schema);
+  const keyShape = schema.shape.key;
+
+  if (!keyShape) {
+    throw new Error(
+      `Schema for tab "${prototype.key}" must include a \`key\` field declared as z.literal('${prototype.key}').`
+    );
+  }
+
+  if (!(keyShape instanceof z.ZodLiteral)) {
+    throw new Error(
+      `Schema for tab "${prototype.key}" must declare the key as a z.literal(...)`
+    );
+  }
+
+  if (keyShape.value !== prototype.key) {
+    throw new Error(
+      `Schema key literal ("${keyShape.value}") does not match prototype key "${prototype.key}".`
+    );
+  }
+}
+
+export class TabFactoryBuilder<Prototypes extends readonly AnyTabPrototype[]> {
+  private constructor(
+    private readonly prototypes: Prototypes,
+    private readonly keys: Set<string>
+  ) {}
+
+  public static create(): TabFactoryBuilder<[]> {
+    return new TabFactoryBuilder<[]>([] as const, new Set());
+  }
+
+  public add<Prototype extends AnyTabPrototype>(
+    prototype: Prototype
+  ): TabFactoryBuilder<[...Prototypes, Prototype]> {
+    if (this.keys.has(prototype.key)) {
+      throw new Error(`Tab prototype with key "${prototype.key}" already exists.`);
+    }
+
+    ensureSchemaHasLiteralKey(prototype);
+
+    const nextPrototypes = [...this.prototypes, prototype] as [...Prototypes, Prototype];
+    const nextKeys = new Set(this.keys);
+    nextKeys.add(prototype.key);
+
+    return new TabFactoryBuilder(nextPrototypes, nextKeys);
+  }
+
+  public build(options?: TabFactoryOptions): TabFactory<Prototypes> {
+    return new TabFactory(this.prototypes, options);
+  }
+}
+
+export function createTabFactoryBuilder(): TabFactoryBuilder<[]> {
+  return TabFactoryBuilder.create();
+}

--- a/src/factory/TabPrototype.ts
+++ b/src/factory/TabPrototype.ts
@@ -40,3 +40,10 @@ export type FactoryInputByKey<
   T extends readonly AnyTabPrototype[],
   Key extends FactoryKey<T>
 > = Extract<FactoryInput<T>, { key: Key }>;
+
+export function createTabPrototype<
+  Key extends string,
+  Schema extends SchemaWithLiteralKey<Key>
+>(prototype: TabPrototype<Key, Schema>): TabPrototype<Key, Schema> {
+  return prototype;
+}

--- a/src/factory/TabPrototype.ts
+++ b/src/factory/TabPrototype.ts
@@ -1,0 +1,42 @@
+import { type ReactElement } from 'react';
+import { z } from 'zod';
+
+// Schemas must carry their literal key so that the discriminated union can
+// narrow values back to the correct prototype at runtime.
+export type SchemaWithLiteralKey<Key extends string> = z.ZodType<
+  { key: Key } & Record<string, unknown>
+>;
+
+export interface TabPrototype<
+  Key extends string,
+  Schema extends SchemaWithLiteralKey<Key>
+> {
+  readonly key: Key;
+  readonly schema: Schema;
+  readonly render: (value: z.infer<Schema>) => ReactElement;
+}
+
+export type AnyTabPrototype = TabPrototype<string, SchemaWithLiteralKey<string>>;
+export type PrototypeUnion<T extends readonly AnyTabPrototype[]> = T[number];
+export type PrototypeSchema<T> = T extends TabPrototype<any, infer Schema>
+  ? Schema
+  : never;
+// Preserve tuple-ness so `z.discriminatedUnion` receives strongly typed schemas.
+export type SchemaTuple<T extends readonly AnyTabPrototype[]> = {
+  [Index in keyof T]: PrototypeSchema<T[Index]>;
+};
+export type PrototypeValue<T> = T extends TabPrototype<any, infer Schema>
+  ? z.infer<Schema>
+  : never;
+export type FactoryInput<T extends readonly AnyTabPrototype[]> = PrototypeValue<
+  PrototypeUnion<T>
+>;
+export type FactoryKey<T extends readonly AnyTabPrototype[]> = PrototypeUnion<T>["key"];
+export type PrototypeForKey<
+  T extends readonly AnyTabPrototype[],
+  Key extends FactoryKey<T>
+> = Extract<PrototypeUnion<T>, { key: Key }>;
+export type FactoryInputByKey<
+  T extends readonly AnyTabPrototype[],
+  Key extends FactoryKey<T>
+> = Extract<FactoryInput<T>, { key: Key }>;

--- a/src/factory/index.ts
+++ b/src/factory/index.ts
@@ -1,0 +1,1 @@
+export * from './TabFactory';

--- a/src/factory/index.ts
+++ b/src/factory/index.ts
@@ -1,1 +1,2 @@
 export * from './TabFactory';
+export * from './TabPrototype';

--- a/src/factory/index.ts
+++ b/src/factory/index.ts
@@ -1,2 +1,3 @@
 export * from './TabFactory';
 export * from './TabPrototype';
+export * from './TabFactoryBuilder';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export * from './factory';


### PR DESCRIPTION
## Summary
- add a schema-driven `TabFactory` along with supporting types
- expose the new factory module through the root entry point

## Testing
- Not Run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c8f3d99d4832682e485b16372b8e7)